### PR TITLE
Using the modules's name instead of modules's name.property.

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -120,7 +120,7 @@ exports.createWinstonLogger = function createWinstonLogger(settings) {
                 ctor = ctor[definition.property];
             }
 
-            transports[definition.property] = ctor;
+            transports[name] = ctor;
         });
     }
 


### PR DESCRIPTION
Currently for config such as:

```
modules: {
        mongodb: {
            name: 'winston-mongodb',
            property: 'MongoDB'
        }
    },
```

`MongoDB` is used as the transport name.  This shouldn't be the case because:
1. `property` is an optional value so if not provided, it'll be undefined.
2. This limits you from using the same module for multiple transports.

(This also allows me to use winston-file transport twice for issue #6.)
